### PR TITLE
one new patch for v1

### DIFF
--- a/patch5
+++ b/patch5
@@ -1,0 +1,51 @@
+From d73ff9b7c4eacaba0fd956d14882bcae970f8307 Mon Sep 17 00:00:00 2001
+From: Oliver Hartkopp <socketcan@hartkopp.net>
+Date: Thu, 26 Nov 2020 20:21:40 +0100
+Subject: can: af_can: can_rx_unregister(): remove WARN() statement from list
+ operation sanity check
+
+To detect potential bugs in CAN protocol implementations (double removal of
+receiver entries) a WARN() statement has been used if no matching list item was
+found for removal.
+
+The fault injection issued by syzkaller was able to create a situation where
+the closing of a socket runs simultaneously to the notifier call chain for
+removing the CAN network device in use.
+
+This case is very unlikely in real life but it doesn't break anything.
+Therefore we just replace the WARN() statement with pr_warn() to preserve the
+notification for the CAN protocol development.
+
+Reported-by: syzbot+381d06e0c8eaacb8706f@syzkaller.appspotmail.com
+Reported-by: syzbot+d0ddd88c9a7432f041e6@syzkaller.appspotmail.com
+Reported-by: syzbot+76d62d3b8162883c7d11@syzkaller.appspotmail.com
+Signed-off-by: Oliver Hartkopp <socketcan@hartkopp.net>
+Link: https://lore.kernel.org/r/20201126192140.14350-1-socketcan@hartkopp.net
+Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>
+---
+ net/can/af_can.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/net/can/af_can.c b/net/can/af_can.c
+index 5d124c1559040..4c343b43067f6 100644
+--- a/net/can/af_can.c
++++ b/net/can/af_can.c
+@@ -541,10 +541,13 @@ void can_rx_unregister(struct net *net, struct net_device *dev, canid_t can_id,
+ 
+ 	/* Check for bugs in CAN protocol implementations using af_can.c:
+ 	 * 'rcv' will be NULL if no matching list item was found for removal.
++	 * As this case may potentially happen when closing a socket while
++	 * the notifier for removing the CAN netdev is running we just print
++	 * a warning here.
+ 	 */
+ 	if (!rcv) {
+-		WARN(1, "BUG: receive list entry not found for dev %s, id %03X, mask %03X\n",
+-		     DNAME(dev), can_id, mask);
++		pr_warn("can: receive list entry not found for dev %s, id %03X, mask %03X\n",
++			DNAME(dev), can_id, mask);
+ 		goto out;
+ 	}
+ 
+-- 
+cgit 1.2.3-1.el7
+


### PR DESCRIPTION
…peration sanity check

To detect potential bugs in CAN protocol implementations (double removal of
receiver entries) a WARN() statement has been used if no matching list item was
found for removal.

The fault injection issued by syzkaller was able to create a situation where
the closing of a socket runs simultaneously to the notifier call chain for
removing the CAN network device in use.

This case is very unlikely in real life but it doesn't break anything.
Therefore we just replace the WARN() statement with pr_warn() to preserve the
notification for the CAN protocol development.

Reported-by: syzbot+381d06e0c8eaacb8706f@syzkaller.appspotmail.com
Reported-by: syzbot+d0ddd88c9a7432f041e6@syzkaller.appspotmail.com
Reported-by: syzbot+76d62d3b8162883c7d11@syzkaller.appspotmail.com
Signed-off-by: Oliver Hartkopp <socketcan@hartkopp.net>
Link: https://lore.kernel.org/r/20201126192140.14350-1-socketcan@hartkopp.net
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>